### PR TITLE
Make it support wheezy by not installing visualvm.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -18,6 +18,7 @@ This role was tested with ansible => 1.5.
 Supported Operating Systems
 ---------------------------
 
+* Debian 7 Wheezy
 * Debian 8 Jessie
 * Ubuntu 14.04 LTS Trusty
 * Ubuntu 12.04 LTS Precise

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,8 +4,13 @@
     - openjdk-7-jre-headless 
     - openjdk-7-jdk
     - maven2
-    - visualvm
   register: install_jdk
+
+- name: install visualvm if available
+  apt: pkg={{item}} state=latest update_cache=yes cache_valid_time=3600
+  with_items:
+    - visualvm
+  when: (ansible_lsb.id == "Debian" and ansible_lsb.major_release|int >= 8) or ansible_lsb.id == "Ubuntu"
 
 - name: set java7 as default
   command: update-alternatives --set java /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java


### PR DESCRIPTION
VisualVM is not packaged for Debian, so let's skip it there (it's not a die-hard dependency). This makes the role work fine with Wheezy.
